### PR TITLE
Singleton non thread safe

### DIFF
--- a/src/Chirp.CLI/Program.cs
+++ b/src/Chirp.CLI/Program.cs
@@ -26,7 +26,9 @@ var arguments = new Docopt().Apply(usage, args, version: "1.0", exit: true)!;
 if (arguments["read"].IsTrue)
 {
     int? limit = null;
-    if (arguments["--limit"] != null)
+    //Check if --limit is different from null or empty string, to ensure that the absence of a limit argument,
+    //does not get treated as an empty string.
+    if (arguments["--limit"] != null && arguments["--limit"].ToString() != "")
     {
         limit = int.Parse(arguments["--limit"].ToString());
     }

--- a/src/Chirp.CLI/Program.cs
+++ b/src/Chirp.CLI/Program.cs
@@ -5,7 +5,7 @@ using SimpleDb;
 
 string timeFormat = "MM/dd/yy HH:mm:ss";
 
-IDatabaseRepository<Cheep> db = new CSVDatabase<Cheep>();
+IDatabaseRepository<Cheep> db = CSVDatabase<Cheep>.Instance;
 
 const string usage = @"Chirp.CLI Version.
 

--- a/src/Chirp.CLI/chirp_cli_db.csv
+++ b/src/Chirp.CLI/chirp_cli_db.csv
@@ -3,3 +3,4 @@ ander,TEST fdsa asdf sadf asdf 123,1725970231
 ander,TEST fdsa afdsfds,1725970812
 bru,What time tho,1725974231
 asger,Test formatting,1725977751
+asger,Singleton?,1726672120

--- a/src/Chirp.CLI/chirp_cli_db.csv
+++ b/src/Chirp.CLI/chirp_cli_db.csv
@@ -4,3 +4,4 @@ ander,TEST fdsa afdsfds,1725970812
 bru,What time tho,1725974231
 asger,Test formatting,1725977751
 asger,Singleton?,1726672120
+asger,Empty string,1726731343

--- a/src/SimpleDb/CSVDatabase.cs
+++ b/src/SimpleDb/CSVDatabase.cs
@@ -5,16 +5,39 @@ using CsvHelper;
 
 public sealed class CSVDatabase<T> : IDatabaseRepository<T>
 {
-    readonly string csvPath = "../Chirp.CLI/chirp_cli_db.csv";
+    private string csvPath = "../Chirp.CLI/chirp_cli_db.csv";
 
-    public CSVDatabase()
+    private static CSVDatabase<T>? instance = null;
+
+    // public CSVDatabase(string csvPath)
+    // {
+    //     this.csvPath = csvPath;
+    // }
+
+    private CSVDatabase()
     {
-        this.csvPath = "../Chirp.CLI/chirp_cli_db.csv";
     }
 
-    public CSVDatabase(string csvPath)
+    public static CSVDatabase<T> Instance
     {
-        this.csvPath = csvPath;
+        get
+        {
+            if (instance == null)
+            {
+
+                instance = new CSVDatabase<T>();
+            }
+            return instance;
+        }
+    }
+
+
+    public void Set_path(string path)
+
+    {
+        csvPath = path;
+
+
     }
 
     public IEnumerable<T> Read(int? limit = null)
@@ -33,7 +56,7 @@ public sealed class CSVDatabase<T> : IDatabaseRepository<T>
     public void Store(T record)
     {
         var fileExists = File.Exists(csvPath);
-        
+
         using (var stream = File.Open(csvPath, FileMode.Append))
         using (var writer = new StreamWriter(stream))
         using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))

--- a/src/SimpleDb/CSVDatabase.cs
+++ b/src/SimpleDb/CSVDatabase.cs
@@ -5,19 +5,18 @@ using CsvHelper;
 
 public sealed class CSVDatabase<T> : IDatabaseRepository<T>
 {
+    //Singleton pattern starts
     private string csvPath = "../Chirp.CLI/chirp_cli_db.csv";
 
     private static CSVDatabase<T>? instance = null;
 
-    // public CSVDatabase(string csvPath)
-    // {
-    //     this.csvPath = csvPath;
-    // }
-
+    //A single constructor, which is private and parameterless. 
+    //This prevents other classes from instantiating it (which would be a violation of the pattern)
     private CSVDatabase()
     {
     }
-
+    //creates an instance of database - It is not thread safe, as many threads could evaluate line_23 to true, concurrently, 
+    //but its ok for now!
     public static CSVDatabase<T> Instance
     {
         get
@@ -31,7 +30,7 @@ public sealed class CSVDatabase<T> : IDatabaseRepository<T>
         }
     }
 
-
+    //Method below can override the field csvPath which has been set when an instance is created
     public void Set_path(string path)
 
     {
@@ -39,6 +38,7 @@ public sealed class CSVDatabase<T> : IDatabaseRepository<T>
 
 
     }
+    //Singleton pattern ends
 
     public IEnumerable<T> Read(int? limit = null)
     {
@@ -48,12 +48,12 @@ public sealed class CSVDatabase<T> : IDatabaseRepository<T>
             //if this was not converted to a list, the IEnumerable would sort of "disappear
             //because the function only uses CsvReader until it returns. Needs more explanation
             var records = csv.GetRecords<T>().ToList();
-            
+
             if (limit.HasValue)
             {
-                return records.Take(limit.Value).ToList();   
+                return records.Take(limit.Value).ToList();
             }
-            else 
+            else
             {
                 return records;
             }

--- a/test/Chirp.CLI.Tests/EndToEndTests.cs
+++ b/test/Chirp.CLI.Tests/EndToEndTests.cs
@@ -14,24 +14,25 @@ public class ChirpCliTests
 
     public ChirpCliTests()
     {
-        CreateTestCsv(); 
+        CreateTestCsv();
     }
 
     [Fact]
     public void TestReadWithLimit()
     {
         // Arrange
-        var csvDatabase = new CSVDatabase<Cheep>(TestCsvPath);
+        var csvDatabase = CSVDatabase<Cheep>.Instance;
+        csvDatabase.Set_path(TestCsvPath);
         var stringWriter = new StringWriter();
         Console.SetOut(stringWriter); // Redirect console output to StringWriter
 
         // Act
-        UserInterface.PrintCheeps(csvDatabase.Read(1)); 
+        UserInterface.PrintCheeps(csvDatabase.Read(1));
 
         // Assert
         var output = stringWriter.ToString().Trim();
-        Assert.Contains("Omar @ 01/01/24 00:00:00: Message 1", output); 
-        Assert.DoesNotContain("Asger", output); 
+        Assert.Contains("Omar @ 01/01/24 00:00:00: Message 1", output);
+        Assert.DoesNotContain("Asger", output);
 
         // Cleanup
         Console.SetOut(new StreamWriter(Console.OpenStandardOutput()));
@@ -42,7 +43,8 @@ public class ChirpCliTests
     public void TestCheepWithMessage()
     {
         // Arrange
-        var csvDatabase = new CSVDatabase<Cheep>(TestCsvPath);
+        var csvDatabase = CSVDatabase<Cheep>.Instance;
+        csvDatabase.Set_path(TestCsvPath);
         var testCheep = new Cheep("Author", "New message!", 1726660160);
 
         // Act
@@ -68,7 +70,7 @@ public class ChirpCliTests
         using (var writer = new StreamWriter(File.Open(TestCsvPath, FileMode.Create)))
         using (var csv = new CsvHelper.CsvWriter(writer, CultureInfo.InvariantCulture))
         {
-            csv.WriteRecords(cheeps); 
+            csv.WriteRecords(cheeps);
         }
     }
 
@@ -81,6 +83,6 @@ public class ChirpCliTests
     [Fact]
     public void Dispose()
     {
-        File.Delete(TestCsvPath); 
+        File.Delete(TestCsvPath);
     }
 }

--- a/test/SimpleDb.Tests/IntegrationTests.cs
+++ b/test/SimpleDb.Tests/IntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace SimpleDb.Tests
@@ -28,7 +29,10 @@ namespace SimpleDb.Tests
         public void StoreAndRetrieveEntry_Success()
         {
             // Arrange
-            var database = new CSVDatabase<Cheep>(testCsvPath);
+            string db = "test_chirp_cli_db.csv";
+
+            var database = CSVDatabase<Cheep>.Instance;
+            database.Set_path(db);
             var cheep = new Cheep
             {
                 Author = "Omar",
@@ -49,7 +53,9 @@ namespace SimpleDb.Tests
         public void StoreMultipleEntriesAndRetrieve_Success()
         {
             // Arrange
-            var database = new CSVDatabase<Cheep>(testCsvPath);
+            string db = "test_chirp_cli_db.csv";
+            var database = CSVDatabase<Cheep>.Instance;
+            database.Set_path(db);
             var cheep1 = new Cheep
             {
                 Author = "Omar",

--- a/test/SimpleDb.Tests/IntegrationTests.cs
+++ b/test/SimpleDb.Tests/IntegrationTests.cs
@@ -29,10 +29,9 @@ namespace SimpleDb.Tests
         public void StoreAndRetrieveEntry_Success()
         {
             // Arrange
-            string db = "test_chirp_cli_db.csv";
 
             var database = CSVDatabase<Cheep>.Instance;
-            database.Set_path(db);
+            database.Set_path(testCsvPath);
             var cheep = new Cheep
             {
                 Author = "Omar",
@@ -53,9 +52,8 @@ namespace SimpleDb.Tests
         public void StoreMultipleEntriesAndRetrieve_Success()
         {
             // Arrange
-            string db = "test_chirp_cli_db.csv";
             var database = CSVDatabase<Cheep>.Instance;
-            database.Set_path(db);
+            database.Set_path(testCsvPath);
             var cheep1 = new Cheep
             {
                 Author = "Omar",


### PR DESCRIPTION
For simplicity i adapted the simplest singleton pattern from: 

https://csharpindepth.com/Articles/Singleton

The implmentation is not thread safe - but that is not a requirement so far. 
With the singleton pattern our database now has a private constructor that is parameterless. 
This means that when we create an instance of our database its path is  set through a private string, and to overwrite that string we now do it through the set_path method - found in CSVDatabase.cs.
This also means that i had to alter the tests that uses a 'test/path', to use the set_path method. I think it will make sense when you see the code.  Additionally  i have added a check for an empty string in src\Chirp.Cli line_31.  We now check if arguments[--limit] is not an empty string, to prevent incorrect parsing.