### PR TITLE
Migrations and deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
         working-directory: src
         env:
           ConnectionString: 'Data Source=./Chirp.Web/chirp.db;' # Adjust path to your database file
-        run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context ChirpDBContext --connection "$ConnectionString"
+        run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context ChirpDBContext --connection "$ConnectionString" --verbosity diagnostic
 
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,9 @@ jobs:
         run: ls -la src/Chirp.Web
 
       - name: Database Migration
-        working-directory: src
+        working-directory: src/Chirp.Web
         env:
-          ConnectionString: 'Data Source=./Chirp.Web/chirp.db;' # Adjust path to your database file
+          ConnectionString: 'Data Source=chirp.db;' # Adjust path to your database file
         run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context ChirpDBContext --connection "$ConnectionString" 
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         working-directory: src
         env:
           ConnectionString: 'Data Source=chirp.db;' # Adjust path to your database file
-        run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context "./Chirp.Infrastructure/Data/ChirpDBContext.cs" --connection "$ConnectionString"
+        run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context "Chirp.Infrastructure.Data.ChirpDBContext" --connection "$ConnectionString"
 
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Database Migration
         working-directory: src
         env:
-          ConnectionString: 'Data Source=chirp.db;' # Adjust path to your database file
+          ConnectionString: 'Data Source=./Chirp.Web/chirp.db;' # Adjust path to your database file
         run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context "Chirp.Infrastructure.Data.ChirpDBContext" --connection "$ConnectionString"
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         working-directory: src
         env:
           ConnectionString: 'Data Source=./Chirp.Web/chirp.db;' # Adjust path to your database file
-        run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context "Chirp.Infrastructure.Data.ChirpDBContext" --connection "$ConnectionString"
+        run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context ChirpDBContext --connection "$ConnectionString"
 
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
 
   #Path to folder in which dotnet stores config files upon 
   #running dotnet publish, which are then deployed to Azure
-  FILE_PATH: "./src/${{ env.FILE_NAME }}/${{ env.FILE_NAME }}-Release"
+  FILE_PATH: "./src/Chirp.Web/Chirp.Web-Release"
 
 #Do this workflow when any version tag is pushed
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,23 +88,6 @@ jobs:
       - name: Install EF Core Tools
         run: dotnet tool install --global dotnet-ef
 
-      - name: Verify dotnet ef command
-        run: |
-          dotnet tool list --global  # List all global tools to check if EF is installed
-          dotnet ef --version          # Check if EF Core is available
-
-      - name: Check current directory
-        run: pwd
-
-      - name: List contents of the working directory
-        run: ls -la
-
-      - name: List contents of src directory
-        run: ls -la src
-
-      - name: List contents of Chirp.Web directory
-        run: ls -la src/Chirp.Web
-
       - name: Database Migration
         working-directory: src/Chirp.Web
         env:
@@ -159,6 +142,16 @@ jobs:
     - name: Install dependencies for ${{ env.FILE_NAME }}
       working-directory: src/${{ env.FILE_NAME }}
       run: dotnet restore
+
+    - name: Install EF Core Tools
+      run: dotnet tool install --global dotnet-ef
+
+    - name: Database Migration
+      working-directory: src/Chirp.Web
+      env:
+        ConnectionString: 'Data Source=chirp.db;' # Adjust path to your database file
+      run: dotnet ef database update --context ChirpDBContext --connection "$ConnectionString" 
+
 
     - name: Build ${{ env.FILE_NAME }}
       working-directory: src/${{ env.FILE_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         working-directory: src
         env:
           ConnectionString: 'Data Source=./Chirp.Web/chirp.db;' # Adjust path to your database file
-        run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context ChirpDBContext --connection "$ConnectionString" --verbosity diagnostic
+        run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context ChirpDBContext --connection "$ConnectionString" 
 
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,12 @@ jobs:
         working-directory: src/${{ env.FILE_NAME }}
         run: dotnet restore
 
+      - name: Database Migration
+        working-directory: src
+        env:
+          ConnectionString: 'Data Source=chirp.db;' # Adjust path to your database file
+        run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context "./Chirp.Infrastructure/Data/ChirpDBContext.cs" --connection "$ConnectionString"
+
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,18 @@ jobs:
           dotnet tool list --global  # List all global tools to check if EF is installed
           dotnet ef --version          # Check if EF Core is available
 
+      - name: Check current directory
+        run: pwd
+
+      - name: List contents of the working directory
+        run: ls -la
+
+      - name: List contents of src directory
+        run: ls -la src
+
+      - name: List contents of Chirp.Web directory
+        run: ls -la src/Chirp.Web
+
       - name: Database Migration
         working-directory: src
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,11 @@ jobs:
         working-directory: src/${{ env.FILE_NAME }}
         run: dotnet restore
 
+      - name: Verify dotnet ef command
+        run: |
+          dotnet tool list --global  # List all global tools to check if EF is installed
+          dotnet ef --version          # Check if EF Core is available
+
       - name: Database Migration
         working-directory: src
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+      - 'TesterTag'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
         working-directory: src/Chirp.Web
         env:
           ConnectionString: 'Data Source=chirp.db;' # Adjust path to your database file
-        run: dotnet ef database update --project ./Chirp.Web/Chirp.Web.csproj --context ChirpDBContext --connection "$ConnectionString" 
+        run: dotnet ef database update --context ChirpDBContext --connection "$ConnectionString" 
 
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,9 @@ jobs:
         working-directory: src/${{ env.FILE_NAME }}
         run: dotnet restore
 
+      - name: Install EF Core Tools
+        run: dotnet tool install --global dotnet-ef
+
       - name: Verify dotnet ef command
         run: |
           dotnet tool list --global  # List all global tools to check if EF is installed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
         tag=$(git describe --tags --abbrev=0)
         release_name="${{ env.FILE_NAME }}-$tag-${{ matrix.target }}"
         # Build everything
-        dotnet publish src/${{ env.FILE_NAME }}/${{ env.FILE_NAME }}.csproj --framework net8.0 --runtime "linux-x64" --self-contained false -c Release -o "src/Chirp.Razor/Chirp.Razor-Release"
+        dotnet publish src/${{ env.FILE_NAME }}/${{ env.FILE_NAME }}.csproj --framework net8.0 --runtime "linux-x64" --self-contained false -c Release -o "src/Chirp.Web/Chirp.Web-Release"
 
     - name: Deploy!!
       uses: azure/webapps-deploy@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Deploy and Release Chirp
 env:
 
   #Name of the csproj file, omit .csproj extension
-  FILE_NAME: Chirp.Razor
+  FILE_NAME: Chirp.Web
 
   #The unique name of the webapp on the Azure Portal
   #This means our webapp address will be https://bdsagroup18chirprazor.azurewebsites.net/
@@ -11,7 +11,7 @@ env:
 
   #Path to folder in which dotnet stores config files upon 
   #running dotnet publish, which are then deployed to Azure
-  FILE_PATH: "./src/Chirp.Razor/Chirp.Razor-Release"
+  FILE_PATH: "./src/${{ env.FILE_NAME }}/${{ env.FILE_NAME }}-Release"
 
 #Do this workflow when any version tag is pushed
 on:

--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.10" />
     <EmbeddedResource Include="data/**/*" />
-    <None Include ="Migrations\**\*">
+    <None Include ="chirp.db">
        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.10" />
     <EmbeddedResource Include="data/**/*" />
-    <None Update="Migrations\**\*">
+    <None Include ="Migrations\**\*">
        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10"/>
     <ProjectReference Include="..\Chirp.Core\Chirp.Core.csproj" />
     <ProjectReference Include="..\Chirp.Infrastructure\Chirp.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SQLite" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.10" />
     <EmbeddedResource Include="data/**/*" />

--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -9,6 +9,9 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.10" />
     <EmbeddedResource Include="data/**/*" />
+    <None Update="Migrations\**\*">
+       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Our workflows now automatically apply migrations to our database.

Currently we deploy the database itself, after the migration has been applied in the workflow. This works for now since we are using a database file within our project, but a better approach would be to have the program apply it on startup (in Program.cs), since deploying an entire database does not sound optimal. 