### PR TITLE
Workflow migrations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,23 +88,6 @@ jobs:
       - name: Install EF Core Tools
         run: dotnet tool install --global dotnet-ef
 
-      
-      - name: Grant Full Permissions to Database File on Windows
-        working-directory: src/${{ env.FILE_NAME }}
-        if: runner.os == 'Windows'
-        run: |
-          icacls "chirp.db" /grant "Everyone:F"
-
-      - name: Check for Migration History Table
-        working-directory: src/${{ env.FILE_NAME }}
-        run: |
-          sqlite3 chirp.db "SELECT name FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory';"
-
-      - name: Database Migration
-        working-directory: src/Chirp.Web
-        env:
-          ConnectionString: 'Data Source=chirp.db;' # Adjust path to your database file
-        run: dotnet-ef database update --context ChirpDBContext --connection "$ConnectionString" 
 
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,7 @@ jobs:
           icacls "chirp.db" /grant "Everyone:F"
 
       - name: Check for Migration History Table
+        working-directory: src/${{ env.FILE_NAME }}
         run: |
           sqlite3 chirp.db "SELECT name FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory';"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,16 +88,6 @@ jobs:
       - name: Install EF Core Tools
         run: dotnet tool install --global dotnet-ef
 
-      - name: Clean Database on Windows
-        working-directory: src/${{ env.FILE_NAME }}
-        if: runner.os == 'Windows'
-        run: |
-          if (Test-Path "chirp.db") {
-            Remove-Item "chirp.db"
-            Write-Host "Deleted existing database."
-          } else {
-            Write-Host "No existing database found."
-          }
       
       - name: Grant Full Permissions to Database File on Windows
         working-directory: src/${{ env.FILE_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,10 @@ jobs:
         run: |
           icacls "chirp.db" /grant "Everyone:F"
 
+      - name: Check for Migration History Table
+        run: |
+          sqlite3 chirp.db "SELECT name FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory';"
+
       - name: Database Migration
         working-directory: src/Chirp.Web
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
         run: dotnet tool install --global dotnet-ef
 
       - name: Clean Database on Windows
+        working-directory: src/${{ env.FILE_NAME }}
         if: runner.os == 'Windows'
         run: |
           if (Test-Path "chirp.db") {
@@ -99,6 +100,7 @@ jobs:
           }
       
       - name: Grant Full Permissions to Database File on Windows
+        working-directory: src/${{ env.FILE_NAME }}
         if: runner.os == 'Windows'
         run: |
           icacls "chirp.db" /grant "Everyone:F"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,21 @@ jobs:
       - name: Install EF Core Tools
         run: dotnet tool install --global dotnet-ef
 
+      - name: Clean Database on Windows
+        if: runner.os == 'Windows'
+        run: |
+          if (Test-Path "chirp.db") {
+            Remove-Item "chirp.db"
+            Write-Host "Deleted existing database."
+          } else {
+            Write-Host "No existing database found."
+          }
+      
+      - name: Grant Full Permissions to Database File on Windows
+        if: runner.os == 'Windows'
+        run: |
+          icacls "chirp.db" /grant "Everyone:F"
+
       - name: Database Migration
         working-directory: src/Chirp.Web
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         working-directory: src/Chirp.Web
         env:
           ConnectionString: 'Data Source=chirp.db;' # Adjust path to your database file
-        run: dotnet ef database update --context ChirpDBContext --connection "$ConnectionString" 
+        run: dotnet-ef database update --context ChirpDBContext --connection "$ConnectionString" 
 
       - name: Build
         shell: bash
@@ -150,7 +150,7 @@ jobs:
       working-directory: src/Chirp.Web
       env:
         ConnectionString: 'Data Source=chirp.db;' # Adjust path to your database file
-      run: dotnet ef database update --context ChirpDBContext --connection "$ConnectionString" 
+      run: dotnet-ef database update --context ChirpDBContext --connection "$ConnectionString" 
 
 
     - name: Build ${{ env.FILE_NAME }}

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -49,6 +49,22 @@ builder.Services.AddAuthentication(options => { })
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    var services = scope.ServiceProvider;
+    var context = services.GetRequiredService<ChirpDBContext>();
+
+    // Apply any pending migrations
+    try
+    {
+        context.Database.Migrate();
+    }
+    catch (Exception ex)
+    {
+        var logger = services.GetRequiredService<ILogger<Program>>();
+        logger.LogError(ex, "An error occurred while migrating the database.");
+    }
+}
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
Our workflow for deployment to Azure would regularly fail on making a release for Windows, while Mac and Linux had no issues. The issue in detail was that the runner could not execute applying migrations to the database, as it could not find the table _EFMigrationsHistory. 

The following problems were considered and inspected:

- Path resolution issues: 

  Windows uses backslashes "\" for paths, while Linux and Mac use forward slashes "/". This could have posed a problem and 
  caused the workflow to be unable to find the database. However, it seems like GitHub Actions automatically resolve path 
  slashes depending on the specified OS. Also, applying migrations in the workflow has previously worked without an issue 
  with the same commands, so this was likely not the issue.

  To reinstate that this was not the cause, I added some bash commands to check if the runner can find the database. It 
  could.


- Missing table in database:

  Following the error trace, EF database update complained about not being able to find the table _EFMigrationsHistory. 
  Upon inspecting the database, I found the same table that was allegedly missing. I added a command before the 
  migrations that would allow Windows full read and write access to the database, thinking it might just not have permission 
  to access that table. This was not the case, the migration failed to apply, unable to find the table.
  
  It is worth noting that we upload our database file when deploying. When the database is up on Azure it is already up to 
  date.

- Applying migrations directly:

  While the workflow migrations suddenly broke,  applying migrations to the database locally was without issues. It could 
  easily find the database and all its tables. Since I was pressed on time, I decided to just make the program apply migrations 
  manually in the Program.cs script, right after building the webapp. This worked, which in turn also made the deployment 
  work. 

  The migrations code in the workflow has been removed, and the deploy workflow now runs as intended.

- Finally:

  I had to update Azure's environment variables, in particular our GitHub ClientId and ClientSecret, that we need to create a 
  user and/or login using an external credentials provider. After this, our Chirp webapp is back online and running (for now)


P.S. the workflow could still use a cleanup, but this is a topic best tackled when waters are calmer, and especially first after project review.