### PR TITLE
Added delete cheeps feature

### DIFF
--- a/src/Chirp.Core/Repositories/ICheepRepository.cs
+++ b/src/Chirp.Core/Repositories/ICheepRepository.cs
@@ -29,4 +29,6 @@ public interface ICheepRepository
 
     public Task Unfollow(string user, string toUnfollow);
 
+    public Task DeleteCheeps(string? authorid, string timestamp, string message);
+
 }

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -37,7 +37,7 @@ public class CheepRepository : ICheepRepository
         {
             AuthorName = cheep.Author?.UserName ?? "Unknown Author", // Handle null here
             Message = cheep.Text,
-            Timestamp = cheep.TimeStamp.ToString()
+            Timestamp = cheep.TimeStamp.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture)
         }).ToList();
     }
 
@@ -60,7 +60,7 @@ public class CheepRepository : ICheepRepository
         {
             AuthorName = cheep.Author?.UserName ?? "Unknown Author", // Handle null here
             Message = cheep.Text,
-            Timestamp = cheep.TimeStamp.ToString()
+            Timestamp = cheep.TimeStamp.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture)
         }).ToList();
     }
 
@@ -95,7 +95,7 @@ public class CheepRepository : ICheepRepository
         {
             AuthorName = cheep.Author?.UserName ?? "Unknown Author", // Handle null here
             Message = cheep.Text,
-            Timestamp = cheep.TimeStamp.ToString()
+            Timestamp = cheep.TimeStamp.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture)
         }).ToList();
 
 
@@ -223,10 +223,11 @@ public class CheepRepository : ICheepRepository
             .Where(c => c.AuthorId == authorid && c.Text == message)
             .ToList();
 
-        //Of the matches find the one that matches on DTO timestamp, and cheep timestamp converted to DTO format 
-        var cheepToDelete = cheeps.SingleOrDefault(c => c.TimeStamp.ToString("dd-MM-yyyy HH:mm:ss") == timestamp);
 
+        var cheepToDelete = cheeps.SingleOrDefault(c => c.TimeStamp.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture) == timestamp);
 
+        Console.WriteLine($"Database: {cheepToDelete?.TimeStamp}");
+        Console.WriteLine($"Input: {timestamp}");
         if (cheepToDelete != null)
         {
 
@@ -234,8 +235,8 @@ public class CheepRepository : ICheepRepository
             await _dbContext.SaveChangesAsync();
 
         }
-
     }
+
 
 
 

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -67,20 +67,21 @@ public class CheepRepository : ICheepRepository
     public async Task<List<CheepDTO>> ReadFromFollows(int pagenum, string author)
     {
 
-        var query = 
-            
+        var query =
+
             from cheeps in _dbContext.Cheeps
-            //Include cheeps of the logged in author
+                //Include cheeps of the logged in author
             where cheeps.Author.UserName == author || (
 
             //Get the IDs of who the current author follows
             //and use that to include their cheeps
                 from authors in _dbContext.Authors
-                where authors.UserName == author 
+                where authors.UserName == author
                 from follow in authors.Follows
                 select follow).Contains(cheeps.Author)
             orderby cheeps.TimeStamp descending
-            select new {
+            select new
+            {
 
                 Author = cheeps.Author,
                 Text = cheeps.Text,
@@ -96,7 +97,7 @@ public class CheepRepository : ICheepRepository
             Message = cheep.Text,
             Timestamp = cheep.TimeStamp.ToString()
         }).ToList();
-            
+
 
 
     }
@@ -195,7 +196,7 @@ public class CheepRepository : ICheepRepository
             author.Follows = [];
         }
 
-    //Linq here also?
+        //Linq here also?
 
         author.Follows.Add(authorToFollow);
 
@@ -212,6 +213,28 @@ public class CheepRepository : ICheepRepository
         author.Follows?.Remove(authorToUnfollow);
 
         await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task DeleteCheeps(string? authorid, string timestamp, string message)
+    {
+
+        //Fetch all cheeps from an author that has a match between DTO message and cheep text
+        var cheeps = _dbContext.Cheeps
+            .Where(c => c.AuthorId == authorid && c.Text == message)
+            .ToList();
+
+        //Of the matches find the one that matches on DTO timestamp, and cheep timestamp converted to DTO format 
+        var cheepToDelete = cheeps.SingleOrDefault(c => c.TimeStamp.ToString("dd-MM-yyyy HH:mm:ss") == timestamp);
+
+
+        if (cheepToDelete != null)
+        {
+
+            _dbContext.Cheeps.Remove(cheepToDelete);
+            await _dbContext.SaveChangesAsync();
+
+        }
+
     }
 
 

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -54,7 +54,8 @@
                             @cheep.Message
                             @if (SignInManager.IsSignedIn(User) && User.Identity?.Name == cheep.AuthorName)
                             {
-                            <form method="post" asp-page-handler="DeleteCheep">
+                            <form method="post" asp-page-handler="DeleteCheep"
+                                onclick="return confirm('Are you sure you want to delete this cheep?')">
                                 <input type="hidden" name="timestamp" value="@cheep.Timestamp" />
                                 <input type="hidden" name="message" value="@cheep.Message" />
                                 <button type="submit" class="btn btn-danger">Delete</button>

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -5,10 +5,11 @@
     Layout = "Shared/_Layout";
 }
 @using Microsoft.AspNetCore.Identity;
+@using Chirp.Web.Pages.Shared;
 @using Chirp.Core.Entities;
 @inject SignInManager<Author> SignInManager;
 @inject UserManager<Author> UserManager;
-    
+
 
 <div>
     <h2> Public Timeline </h2>
@@ -19,35 +20,46 @@
         <ul id="messagelist" class="cheeps">
             @foreach (var cheep in Model.Cheeps)
             {
+
                 <li>
                     <p>
                         <strong>
                             <a href="/@cheep.AuthorName">@cheep.AuthorName</a>
-                            @if (SignInManager.IsSignedIn(User) && User.Identity?.Name != cheep.AuthorName) {
-                                @if (User.Identity?.Name != null && !await Model._CheepRepository.Follows(User.Identity.Name, cheep.AuthorName))
+                            @if (SignInManager.IsSignedIn(User) && User.Identity?.Name != cheep.AuthorName)
+                            {
+                                @if (User.Identity?.Name != null && !await Model._CheepRepository.Follows(User.Identity.Name,
+                               cheep.AuthorName))
                                 {
                                     <form method="post">
-                                    <button class = "button" name = "followbutton" asp-page-handler="Follow">
-                                        <span>Follow</span>
-                                    </button>
-                                    <input name="user" value="@User.Identity.Name" type="hidden">
-                                    <input name="toFollow" value="@cheep.AuthorName" type="hidden">
+                                        <button class="button" name="followbutton" asp-page-handler="Follow">
+                                            <span>Follow</span>
+                                        </button>
+                                        <input name="user" value="@User.Identity.Name" type="hidden">
+                                        <input name="toFollow" value="@cheep.AuthorName" type="hidden">
                                     </form>
                                 }
                                 else
                                 {
                                     <form method="post">
-                                    <button class = "button" name = "unfollowbutton" asp-page-handler="Unfollow">
-                                        <span>Unfollow</span>
-                                    </button>
-                                    <input name="user" value="@User.Identity?.Name" type="hidden">
-                                    <input name="toUnfollow" value="@cheep.AuthorName" type="hidden">
+                                        <button class="button" name="unfollowbutton" asp-page-handler="Unfollow">
+                                            <span>Unfollow</span>
+                                        </button>
+                                        <input name="user" value="@User.Identity?.Name" type="hidden">
+                                        <input name="toUnfollow" value="@cheep.AuthorName" type="hidden">
                                     </form>
                                 }
-                                }
+                            }
                         </strong>
                     <div style="word-wrap: break-word;">
                             @cheep.Message
+                            @if (SignInManager.IsSignedIn(User) && User.Identity?.Name == cheep.AuthorName)
+                            {
+                            <form method="post" asp-page-handler="DeleteCheep">
+                                <input type="hidden" name="timestamp" value="@cheep.Timestamp" />
+                                <input type="hidden" name="message" value="@cheep.Message" />
+                                <button type="submit" class="btn btn-danger">Delete</button>
+                            </form>
+                            }
                     </div>
                     <small>&mdash; @cheep.Timestamp</small>
                     </p>

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -9,6 +9,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Components.Forms;
 using Chirp.Web.Pages.Shared;
 using System.Security.Claims;
+using Chirp.Infrastructure.Repositories;
 
 
 namespace Chirp.Web.Pages;
@@ -31,6 +32,7 @@ public class PublicModel : PageModel
         _CheepRepository = cheepRepository;
         _CheepService = cheepService;
     }
+
 
     public async Task<ActionResult> OnGet([FromQuery] int page)
     {
@@ -79,6 +81,18 @@ public class PublicModel : PageModel
         await _CheepRepository.Unfollow(user, toUnfollow);
         return RedirectToPage();
     }
+
+    public async Task<IActionResult> OnPostDeleteCheep(string timestamp, string message)
+    {
+
+        var userid = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        await _CheepRepository.DeleteCheeps(userid, timestamp, message);
+
+        return RedirectToPage();
+
+    }
+
 
 
 }

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -23,6 +23,14 @@
                         </strong>
                     <div style="word-wrap: break-word;">
                             @cheep.Message
+                            @if (User.Identity?.Name == cheep.AuthorName)
+                            {
+                            <form method="post" asp-page-handler="DeleteCheep">
+                                <input type="hidden" name="timestamp" value="@cheep.Timestamp" />
+                                <input type="hidden" name="message" value="@cheep.Message" />
+                                <button type="submit" class="btn btn-danger">Delete</button>
+                            </form>
+                            }
                     </div>
                     <small>&mdash; @cheep.Timestamp</small>
                     </p>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -25,7 +25,8 @@
                             @cheep.Message
                             @if (User.Identity?.Name == cheep.AuthorName)
                             {
-                            <form method="post" asp-page-handler="DeleteCheep">
+                            <form method="post" asp-page-handler="DeleteCheep"
+                                onclick="return confirm('Are you sure you want to delete this cheep?')">
                                 <input type="hidden" name="timestamp" value="@cheep.Timestamp" />
                                 <input type="hidden" name="message" value="@cheep.Message" />
                                 <button type="submit" class="btn btn-danger">Delete</button>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -61,4 +61,15 @@ public class UserTimelineModel(ICheepRepository cheepRepository, ICheepService c
         return RedirectToPage();
     }
 
+    public async Task<IActionResult> OnPostDeleteCheep(string timestamp, string message)
+    {
+
+        var userid = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        await _CheepRepository.DeleteCheeps(userid, timestamp, message);
+
+        return RedirectToPage();
+
+    }
+
 }

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -29,9 +29,9 @@ builder.Services.AddAuthentication(options => { })
         // Use different secrets based on the environment
         if (builder.Environment.IsDevelopment())
         {
-            o.ClientId = builder.Configuration["authentication:github:clientId:local"] ?? 
+            o.ClientId = builder.Configuration["authentication:github:clientId:local"] ??
                          throw new ArgumentException("GitHub ClientId for local dev not provided.");
-            o.ClientSecret = builder.Configuration["authentication:github:clientSecret:local"] ?? 
+            o.ClientSecret = builder.Configuration["authentication:github:clientSecret:local"] ??
                              throw new ArgumentException("GitHub ClientSecret for local dev not provided.");
         }
         else
@@ -47,13 +47,16 @@ builder.Services.AddAuthentication(options => { })
         o.CallbackPath = "/signin-github";
     });
 
-builder.WebHost.ConfigureKestrel(options =>
+if (builder.Environment.IsDevelopment())
 {
-    options.ListenLocalhost(5001, listenOptions =>
+    builder.WebHost.ConfigureKestrel(options =>
     {
-        listenOptions.UseHttps(); // Enable HTTPS on port 5001
+        options.ListenLocalhost(5001, listenOptions =>
+        {
+            listenOptions.UseHttps(); // Enable HTTPS on port 5001
+        });
     });
-});
+}
 
 
 var app = builder.Build();

--- a/test/PlaywrightTests/UiTests.cs
+++ b/test/PlaywrightTests/UiTests.cs
@@ -1,4 +1,4 @@
-//pwsh bin/Debug/net8.0/playwright.ps1 codegen https://localhost:5001
+//IN WSL: pwsh bin/Debug/net8.0/playwright.ps1 codegen https://localhost:5001
 
 using System.Diagnostics;
 using Microsoft.Playwright;
@@ -159,7 +159,7 @@ public class EndToEndTests : PageTest
         await _page!.Locator("#cheepTextInput").ClickAsync();
         await _page!.Locator("#cheepTextInput").FillAsync("Hello, I am feeling good!<script>alert('If you see this in a popup, you are in trouble!');</script>");
         await _page!.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
-        await Expect(_page!.Locator("#messagelist")).ToContainTextAsync("test@mail.dk Hello, I am feeling good!<script>alert('If you see this in a popup, you are in trouble!');</script> —");
+        await Expect(_page!.Locator("#messagelist")).ToContainTextAsync("test@mail.dk Hello, I am feeling good!<script>alert('If you see this in a popup, you are in trouble!');</script>");
         await _page!.GetByRole(AriaRole.Link, new() { Name = "logout [test@mail.dk]" }).ClickAsync();
         await _page!.GetByRole(AriaRole.Button, new() { Name = "Click here to Logout" }).ClickAsync();
     }

--- a/test/PlaywrightTests/UiTests.cs
+++ b/test/PlaywrightTests/UiTests.cs
@@ -71,14 +71,14 @@ public class EndToEndTests : PageTest
     {
         // go to homepage and login using a testuser
         await _page!.GotoAsync("https://localhost:5001");
-        await _page!.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
-        await _page!.GetByPlaceholder("password").ClickAsync();
-        await _page!.GetByPlaceholder("password").FillAsync("Hello_1");
-        await _page!.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+        await _page.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
+        await _page.GetByPlaceholder("password").ClickAsync();
+        await _page.GetByPlaceholder("password").FillAsync("Hello_1");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
         // see if 'whats on your mind' heading now appears after login
-        await Expect(_page!.GetByRole(AriaRole.Heading, new() { Name = "What's on your mind test@mail" })).ToBeVisibleAsync();
+        await Expect(_page.GetByRole(AriaRole.Heading, new() { Name = "What's on your mind test@mail" })).ToBeVisibleAsync();
 
     }
     [Test]
@@ -86,15 +86,15 @@ public class EndToEndTests : PageTest
     {
         // Log in using a test user
         await _page!.GotoAsync("https://localhost:5001");
-        await _page!.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
-        await _page!.GetByPlaceholder("password").ClickAsync();
-        await _page!.GetByPlaceholder("password").FillAsync("Hello_1");
-        await _page!.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
-        await _page!.GotoAsync("https://localhost:5001");
+        await _page.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
+        await _page.GetByPlaceholder("password").ClickAsync();
+        await _page.GetByPlaceholder("password").FillAsync("Hello_1");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+        await _page.GotoAsync("https://localhost:5001");
         // see if share button is now visible after login
-        await Expect(_page!.GetByRole(AriaRole.Button, new() { Name = "Share" })).ToBeVisibleAsync();
+        await Expect(_page.GetByRole(AriaRole.Button, new() { Name = "Share" })).ToBeVisibleAsync();
     }
 
     [Test]
@@ -102,14 +102,14 @@ public class EndToEndTests : PageTest
     {
         var CheepLongerthan160 = "Planning an amazing event takes effort, but teamwork and creativity make it unforgettable. Lets aim for success and celebrate together. Join us soon—excited! Also you should cut me off soon";
         await _page!.GotoAsync("https://localhost:5001");
-        await _page!.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
-        await _page!.GetByPlaceholder("password").ClickAsync();
-        await _page!.GetByPlaceholder("password").FillAsync("Hello_1");
-        await _page!.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
-        await _page!.Locator("#cheepTextInput").ClickAsync();
-        await _page!.Locator("#cheepTextInput").FillAsync(CheepLongerthan160);
+        await _page.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
+        await _page.GetByPlaceholder("password").ClickAsync();
+        await _page.GetByPlaceholder("password").FillAsync("Hello_1");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+        await _page.Locator("#cheepTextInput").ClickAsync();
+        await _page.Locator("#cheepTextInput").FillAsync(CheepLongerthan160);
         string actual = await _page!.Locator("#cheepTextInput").InputValueAsync();
 
         Assert.That(actual.Length, Is.EqualTo(160));
@@ -121,24 +121,23 @@ public class EndToEndTests : PageTest
     {
 
         await _page!.GotoAsync("https://localhost:5001");
-        await _page!.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
-        await _page!.GetByPlaceholder("password").ClickAsync();
-        await _page!.GetByPlaceholder("password").FillAsync("Hello_1");
-        await _page!.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
-        await _page!.GetByRole(AriaRole.Link, new() { Name = "my timeline" }).ClickAsync();
-        await _page!.Locator("#cheepTextInput").ClickAsync();
-        await _page!.Locator("#cheepTextInput").FillAsync("Hello i am test");
-        await _page!.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
-        await Expect(_page!.Locator("#messagelist")).ToContainTextAsync("Hello i am test");
-
-        await _page!.GetByRole(AriaRole.Link, new() { Name = "logout [test@mail.dk]" }).ClickAsync();
-        await _page!.GetByRole(AriaRole.Button, new() { Name = "Click here to Logout" }).ClickAsync();
-        await _page!.GetByRole(AriaRole.Link, new() { Name = "public timeline" }).ClickAsync();
-        await Expect(_page!.GetByRole(AriaRole.Link, new() { Name = "logout [test@mail.dk]" })).Not.ToBeVisibleAsync();
-        await Expect(_page!.GetByRole(AriaRole.Link, new() { Name = "login" })).ToBeVisibleAsync();
-        await Expect(_page!.Locator("#messagelist")).ToContainTextAsync("Hello i am test");
+        await _page.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
+        await _page.GetByPlaceholder("password").ClickAsync();
+        await _page.GetByPlaceholder("password").FillAsync("Hello_1");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+        await _page.GetByRole(AriaRole.Link, new() { Name = "my timeline" }).ClickAsync();
+        await _page.Locator("#cheepTextInput").ClickAsync();
+        await _page.Locator("#cheepTextInput").FillAsync("Hello i am test");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
+        await Expect(_page.Locator("#messagelist")).ToContainTextAsync("Hello i am test");
+        await _page.GetByRole(AriaRole.Link, new() { Name = "logout [test@mail.dk]" }).ClickAsync();
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Click here to Logout" }).ClickAsync();
+        await _page.GetByRole(AriaRole.Link, new() { Name = "public timeline" }).ClickAsync();
+        await Expect(_page.GetByRole(AriaRole.Link, new() { Name = "logout [test@mail.dk]" })).Not.ToBeVisibleAsync();
+        await Expect(_page.GetByRole(AriaRole.Link, new() { Name = "login" })).ToBeVisibleAsync();
+        await Expect(_page.Locator("#messagelist")).ToContainTextAsync("Hello i am test");
 
     }
 
@@ -147,22 +146,79 @@ public class EndToEndTests : PageTest
     public async Task LogInAndTestVulnerabilityToXss()
     {
         await _page!.GotoAsync("https://localhost:5001/");
-        await _page!.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").ClickAsync();
-        await _page!.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
-        await _page!.GetByPlaceholder("password").ClickAsync();
-        await _page!.GetByPlaceholder("password").FillAsync("Hello_1");
-        await _page!.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
-        await Expect(_page!.GetByRole(AriaRole.Heading, new() { Name = "What's on your mind test@mail" })).ToBeVisibleAsync();
-        await Expect(_page!.GetByRole(AriaRole.Link, new() { Name = "logout [test@mail.dk]" })).ToBeVisibleAsync();
-        await _page!.Locator("#cheepTextInput").ClickAsync();
-        await _page!.Locator("#cheepTextInput").FillAsync("Hello, I am feeling good!<script>alert('If you see this in a popup, you are in trouble!');</script>");
-        await _page!.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
-        await Expect(_page!.Locator("#messagelist")).ToContainTextAsync("test@mail.dk Hello, I am feeling good!<script>alert('If you see this in a popup, you are in trouble!');</script>");
-        await _page!.GetByRole(AriaRole.Link, new() { Name = "logout [test@mail.dk]" }).ClickAsync();
-        await _page!.GetByRole(AriaRole.Button, new() { Name = "Click here to Logout" }).ClickAsync();
+        await _page.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
+        await _page.GetByPlaceholder("password").ClickAsync();
+        await _page.GetByPlaceholder("password").FillAsync("Hello_1");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+        await Expect(_page.GetByRole(AriaRole.Heading, new() { Name = "What's on your mind test@mail" })).ToBeVisibleAsync();
+        await Expect(_page.GetByRole(AriaRole.Link, new() { Name = "logout [test@mail.dk]" })).ToBeVisibleAsync();
+        await _page.Locator("#cheepTextInput").ClickAsync();
+        await _page.Locator("#cheepTextInput").FillAsync("Hello, I am feeling good!<script>alert('If you see this in a popup, you are in trouble!');</script>");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
+        await Expect(_page.Locator("#messagelist")).ToContainTextAsync("test@mail.dk Hello, I am feeling good!<script>alert('If you see this in a popup, you are in trouble!');</script>");
+        await _page.GetByRole(AriaRole.Link, new() { Name = "logout [test@mail.dk]" }).ClickAsync();
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Click here to Logout" }).ClickAsync();
     }
 
 
+    [Test]
+    public async Task DeleteCheepFromPrivateAndPublic()
+    {
+        await _page!.GotoAsync("https://localhost:5001/");
+        await _page.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").ClickAsync();
+        await _page.GetByPlaceholder("name@example.com").FillAsync("test@mail.dk");
+        await _page.GetByPlaceholder("password").ClickAsync();
+        await _page.GetByPlaceholder("password").FillAsync("Hello_1");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+        await _page.Locator("#cheepTextInput").ClickAsync();
+        await _page.Locator("#cheepTextInput").FillAsync("Delete me from public");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
+        await Expect(_page.Locator("#messagelist")).ToContainTextAsync("Delete me from public");
+        //await Expect(_page.GetByRole(AriaRole.Button, new() { Name = "Delete" })).ToBeVisibleAsync();
+
+        void Page_Dialog_EventHandler(object sender, IDialog dialog)
+        {
+            //Console.WriteLine($"Dialog message: {dialog.Message}");
+            dialog.AcceptAsync();
+            _page.Dialog -= Page_Dialog_EventHandler;
+        }
+        _page.Dialog += Page_Dialog_EventHandler;
+        await _page.Locator("li").Filter(new() { HasText = "test@mail.dk Delete me from public" }).GetByRole(AriaRole.Button).ClickAsync();
+
+        await Expect(_page.Locator("#messagelist")).Not.ToContainTextAsync("Delete me from public");
+
+        await _page.GetByRole(AriaRole.Link, new() { Name = "my timeline" }).ClickAsync();
+
+        await _page.Locator("#cheepTextInput").ClickAsync();
+        await _page.Locator("#cheepTextInput").FillAsync("Delete me from private");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
+        //await Expect(_page.GetByRole(AriaRole.Button, new() { Name = "Delete" })).ToBeVisibleAsync();
+
+        await Expect(_page.Locator("#messagelist")).ToContainTextAsync("Delete me from private");
+
+        void Page2_Dialog_EventHandler(object sender, IDialog dialog)
+        {
+            //Console.WriteLine($"Dialog message: {dialog.Message}");
+            dialog.AcceptAsync();
+            _page.Dialog -= Page2_Dialog_EventHandler;
+        }
+        _page.Dialog += Page2_Dialog_EventHandler;
+        await _page.Locator("li").Filter(new() { HasText = "test@mail.dk Delete me from private" }).GetByRole(AriaRole.Button).ClickAsync();
+
+        //await Expect(_page.GetByRole(AriaRole.Button, new() { Name = "Delete" })).Not.ToBeVisibleAsync();
+
+        await _page.GetByRole(AriaRole.Link, new() { Name = "public timeline" }).ClickAsync();
+
+        await Expect(_page.Locator("#messagelist")).Not.ToContainTextAsync("Delete me from private");
+
+        await Expect(_page.Locator("#messagelist")).Not.ToContainTextAsync("Delete me from public");
+
+    }
 }
+
+
+

--- a/test/PlaywrightTests/util.cs
+++ b/test/PlaywrightTests/util.cs
@@ -45,7 +45,7 @@ namespace PlaywrightTests
             {
                 if (!string.IsNullOrEmpty(args.Data))
                 {
-                    Console.WriteLine(args.Data);
+                    //Console.WriteLine(args.Data); Uncomment this line for debugging of Playwright tests!
 
                     if (args.Data.Contains("Now listening on") || args.Data.Contains("Application started"))
                     {

--- a/test/RazorApp.Tests/UnitTest.cs
+++ b/test/RazorApp.Tests/UnitTest.cs
@@ -109,7 +109,7 @@ namespace RazorApp.Tests
             //Arrange
             var ta1 = new Author() { Id = "13", UserName = "My Name Test", Email = "test@itu.dk", Cheeps = new List<Cheep>() };
 
-            var tc1 = new Cheep() { CheepId = 658, AuthorId = ta1.Id, Author = ta1, Text = "This is my first cheep", TimeStamp = DateTime.UtcNow };
+            var tc1 = new Cheep() { CheepId = 658, AuthorId = ta1.Id, Author = ta1, Text = "This is my first cheep", TimeStamp = DateTime.Parse("2024-08-01 16:34:58") };
 
             //Act
             await StartMockDB();

--- a/test/RazorApp.Tests/UnitTest.cs
+++ b/test/RazorApp.Tests/UnitTest.cs
@@ -109,7 +109,7 @@ namespace RazorApp.Tests
             //Arrange
             var ta1 = new Author() { Id = "13", UserName = "My Name Test", Email = "test@itu.dk", Cheeps = new List<Cheep>() };
 
-            var tc1 = new Cheep() { CheepId = 658, AuthorId = ta1.Id, Author = ta1, Text = "This is my first cheep", TimeStamp = DateTime.Now };
+            var tc1 = new Cheep() { CheepId = 658, AuthorId = ta1.Id, Author = ta1, Text = "This is my first cheep", TimeStamp = DateTime.UtcNow };
 
             //Act
             await StartMockDB();

--- a/test/RazorApp.Tests/UnitTest.cs
+++ b/test/RazorApp.Tests/UnitTest.cs
@@ -2,9 +2,16 @@ using Chirp.Infrastructure.Data;
 using Chirp.Infrastructure.Repositories;
 using Chirp.Core.Entities;
 using Chirp.Core.Repositories;
+using Chirp.Core;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Chirp.Infrastructure.Services;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Humanizer;
+using Chirp.Core.DTOs;
+using System.Globalization;
+using NuGet.Packaging.Signing;
+using System.Net.Http.Headers;
 
 namespace RazorApp.Tests
 
@@ -109,17 +116,30 @@ namespace RazorApp.Tests
             //Arrange
             var ta1 = new Author() { Id = "13", UserName = "My Name Test", Email = "test@itu.dk", Cheeps = new List<Cheep>() };
 
-            var tc1 = new Cheep() { CheepId = 658, AuthorId = ta1.Id, Author = ta1, Text = "This is my first cheep", TimeStamp = DateTime.Parse("2024-08-01 16:34:58") };
+            var tc1 = new Cheep() { CheepId = 658, AuthorId = ta1.Id, Author = ta1, Text = "This is my first cheep", TimeStamp = DateTime.Now };
 
             //Act
             await StartMockDB();
             await _repo.AddCheep(tc1);
 
-            await _repo.DeleteCheeps(tc1.AuthorId, tc1.TimeStamp.ToString(), tc1.Text);
+
+            var CheepDTO = new CheepDTO
+            {
+
+                AuthorName = tc1.AuthorId,
+                Message = tc1.Text,
+                Timestamp = tc1.TimeStamp.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture)
+
+            };
+
+            await _repo.DeleteCheeps(CheepDTO.AuthorName, CheepDTO.Timestamp, CheepDTO.Message);
+
+            //actualCheep = await _context.Cheeps.Where(cheep => cheep.CheepId == 658).FirstOrDefaultAsync();
 
             //Assert
             //if no record is found FirstOrDefaultAsync will return default value, which is NULL for our cheeps
             var actualCheep = await _context.Cheeps.Where(cheep => cheep.CheepId == 658).FirstOrDefaultAsync();
+
             Assert.Null(actualCheep);
         }
 

--- a/test/RazorApp.Tests/UnitTest.cs
+++ b/test/RazorApp.Tests/UnitTest.cs
@@ -103,6 +103,27 @@ namespace RazorApp.Tests
         }
 
         [Fact]
+        public async Task Cheep_IsDeletedFromDB()
+        {
+
+            //Arrange
+            var ta1 = new Author() { Id = "13", UserName = "My Name Test", Email = "test@itu.dk", Cheeps = new List<Cheep>() };
+
+            var tc1 = new Cheep() { CheepId = 658, AuthorId = ta1.Id, Author = ta1, Text = "This is my first cheep", TimeStamp = DateTime.Now };
+
+            //Act
+            await StartMockDB();
+            await _repo.AddCheep(tc1);
+
+            await _repo.DeleteCheeps(tc1.AuthorId, tc1.TimeStamp.ToString(), tc1.Text);
+
+            //Assert
+            //if no record is found FirstOrDefaultAsync will return default value, which is NULL for our cheeps
+            var actualCheep = await _context.Cheeps.Where(cheep => cheep.CheepId == 658).FirstOrDefaultAsync();
+            Assert.Null(actualCheep);
+        }
+
+        [Fact]
         public async Task AddedAuthor_IsSavedToDB()
         {
             //Arrange


### PR DESCRIPTION
Users can now delete their cheeps from Public and Private timeline. The Delete button has the same design as our follow form, and it resides in Public, and private timeline pages. When clicking the button the user will be promted with a popup confirmation, where a user can either press ok or cancel. 

The method that deletes a cheep from db resides in CheepRepository.cs. The method uses authorid, message and timestamp, which is extracted from a cheepDTO, to filter the database and find the correct cheep to remove. If cheepDTO had cheepID we could refactor this method and make it more robust. 

I have also added a UI test(Playwright) and a Unit test for the feature.