### PR TITLE
We had this bug where our program would 'break' if a user tried to share an empty cheep. This PR should fix that

### DIFF
--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -43,11 +43,12 @@ public class PublicModel : PageModel
         return Page();
     }
 
-    public async Task<ActionResult> OnPost()
+    public async Task<ActionResult> OnPost([FromQuery] int page)
     {
         if (!ModelState.IsValid)
         {
-            ModelState.AddModelError("CheepText", "You have exeeded max length for cheeps");
+            if (page <= 0) page = 1;
+            Cheeps = await _CheepRepository.ReadPublicTimeline(page);
             return Page();
         }
 

--- a/src/Chirp.Web/Pages/Shared/_CheepboxPartial.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_CheepboxPartial.cshtml
@@ -16,16 +16,14 @@ Context.Request.Path.Equals("/")))
 {
 
     <div class="cheepbox">
-    <h3>What's on your mind @(User.Identity?.Name)</h3>
-    <form method="post">
-        <input type="text" asp-for="CheepText" id="cheepTextInput">
-        <span asp-validation-for="CheepText" class="text-danger"></span>
-        <p id="charCount" class="text-muted">160 characters remaining</p>
-        <input type="submit" value="Share">
-
-
-    </form>
-</div>
+        <h3>What's on your mind @(User.Identity?.Name)</h3>
+        <form method="post">
+            <div asp-validation-summary="All" class="text-danger"></div>
+            <input type="text" asp-for="CheepText" id="cheepTextInput">
+            <p id="charCount" class="text-muted">160 characters remaining</p>
+            <input type="submit" value="Share">
+        </form>
+    </div>
 
 }
 

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -36,11 +36,12 @@ public class UserTimelineModel(ICheepRepository cheepRepository, ICheepService c
         return Page();
     }
 
-    public async Task<ActionResult> OnPost()
+    public async Task<ActionResult> OnPost([FromQuery] int page)
     {
         if (!ModelState.IsValid)
         {
-            ModelState.AddModelError("CheepText", "You have exceeded the max length for cheeps");
+            if (page <= 0) page = 1;
+            Cheeps = await _CheepRepository.ReadFromFollows(page, Author);
             return Page();
         }
 


### PR DESCRIPTION


If a user tries to share an empty cheep an error message will appear instead of an exeption being thrown. We had to alter the onPost methods for user and public timeline. If a modelstate is not valid which is the case when an empty cheep is posted, we ensure that our CheepDTO list is populated, before we return the page. If not we will return to a page where error message is correctly shown, but no cheeps are shown on the respective timeline.